### PR TITLE
Remove extra errno definition in lwip port

### DIFF
--- a/middleware/lwip/port/sys_arch.c
+++ b/middleware/lwip/port/sys_arch.c
@@ -60,10 +60,6 @@
 #include "lwip/init.h"
 #endif
 
-#ifndef errno
-int errno = 0;
-#endif
-
 /*
  * Prints an assertion messages and aborts execution.
  */


### PR DESCRIPTION
- During exploration of a toolchain upgrade, ran into this extra definition of errno which caused duplicate linking errors. No issues building on gcc-9 after removing this, so let's go ahead and drop it.